### PR TITLE
Reduce size in `genJson` to prevent excessively large structures

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,6 @@
     "purescript-maps": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-strongcheck": "^3.1.0"
+    "purescript-quickcheck": "^4.6.1"
   }
 }

--- a/src/Data/Argonaut/Gen.purs
+++ b/src/Data/Argonaut/Gen.purs
@@ -15,7 +15,7 @@ import Data.String as S
 import Data.StrMap as SM
 
 genJson :: forall m. MonadGen m => MonadRec m => Lazy (m J.Json) => m J.Json
-genJson = Gen.resize (min 10) $ Gen.sized genJson'
+genJson = Gen.resize (min 5) $ Gen.sized genJson'
   where
   genJson' :: Int -> m J.Json
   genJson' size
@@ -23,7 +23,7 @@ genJson = Gen.resize (min 10) $ Gen.sized genJson'
     | otherwise = genLeaf
 
   genLeaf :: m J.Json
-  genLeaf = Gen.oneOf $ pure J.jsonNull :| [ genJBoolean, genJNumber, genJString]
+  genLeaf = Gen.oneOf $ pure J.jsonNull :| [genJBoolean, genJNumber, genJString]
 
   genJArray :: m J.Json
   genJArray = J.fromArray <$> Gen.unfoldable (defer \_ -> genJson)


### PR DESCRIPTION
Also switch to using QuickCheck, since it was fixing a bug in there revealed how the current size is a little silly.