### PR TITLE
Inline `objToString` and `objKeys`

### DIFF
--- a/src/Data/Argonaut/Core.js
+++ b/src/Data/Argonaut/Core.js
@@ -16,11 +16,8 @@ exports.stringify = function (j) {
   return JSON.stringify(j);
 };
 
-var objToString = Object.prototype.toString;
-var objKeys = Object.keys;
-
 function isArray(a) {
-  return objToString.call(a) === "[object Array]";
+  return Object.prototype.toString.call(a) === "[object Array]";
 }
 
 exports._caseJson = function (isNull, isBool, isNum, isStr, isArr, isObj, j) {
@@ -28,7 +25,7 @@ exports._caseJson = function (isNull, isBool, isNum, isStr, isArr, isObj, j) {
   else if (typeof j === "boolean") return isBool(j);
   else if (typeof j === "number") return isNum(j);
   else if (typeof j === "string") return isStr(j);
-  else if (objToString.call(j) === "[object Array]")
+  else if (Object.prototype.toString.call(j) === "[object Array]")
     return isArr(j);
   else return isObj(j);
 };
@@ -83,8 +80,8 @@ exports._compare = function _compare (EQ, GT, LT, a, b) {
     else if (typeof b === "string") return GT;
     else if (isArray(b)) return GT;
     else {
-      var akeys = objKeys(a);
-      var bkeys = objKeys(b);
+      var akeys = Object.keys(a);
+      var bkeys = Object.keys(b);
       if (akeys.length < bkeys.length) return LT;
       else if (akeys.length > bkeys.length) return GT;
       var keys = akeys.concat(bkeys).sort();


### PR DESCRIPTION
## What does this pull request do?

Ran into an issue when using `purs bundle` on some code where I was using `Prelude.eq` on two `Data.Argonaut.Core.Json` values. `purs bundle` would remove `objToString` and then crash with `ReferenceError: objToString is not defined`.

The changes here inline the `var`s so `purs bundle` doesn't decide to remove them.

## Where should the reviewer start?

* This was originally changed in https://github.com/purescript-contrib/purescript-argonaut-core/commit/b0149503a66f7f4464bf3992bb20221de0923e28. That commit says it was fixing warnings. Not sure if the extraction of `objToString` and `objKeys` were essential to the fix. If so, but the tests pass now, it seems fine to make these changes. Am I understanding correctly?
* There's a bug in `purs bundle` that's existed for many versions: https://github.com/purescript/purescript/issues/3259. If you want to understand why this happens, that issue and any related ones are probably a good place to start.
* It looks like `objKeys` is okay because it's referenced directly from `_compare` (which is where it's used). I didn't want to take the chance, so I inlined both.

## How should this be manually tested?

You can reproduce it with this module:
```PureScript
module Main (main) where

import Prelude

import Data.Argonaut.Core as Data.Argonaut.Core
import Effect as Effect
import Effect.Console as Effect.Console

main :: Effect.Effect Unit
main =
  Effect.Console.logShow
    (Data.Argonaut.Core.jsonEmptyObject == Data.Argonaut.Core.jsonEmptyObject)
```
And then the following commands:
```console
$ purs compile src/**/*.purs bower_components/purescript-*/src/**/*.purs
<bunch-of-output>
$ purs bundle --main Main --module Main --output output/main.js output/*/index.js output/*/foreign.js
$ node output/main.js
/home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:13
    return objToString.call(a) === "[object Array]";
    ^

ReferenceError: objToString is not defined
    at isArray (/home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:13:5)
    at Object._compare (/home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:45:16)
    at /home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:198:38
    at /home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:203:84
    at /home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:267:133
    at Object.<anonymous> (/home/joneshf/programming/purescript-contrib/purescript-argonaut-core/output/main.js:269:3)
    at Module._compile (internal/modules/cjs/loader.js:799:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:810:10)
    at Module.load (internal/modules/cjs/loader.js:666:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:606:12)
```

## Other Notes:

The contribution guidelines recommend adding a test case to track this bug. I'm more than happy to do that, but it would require a different test suite than what's there. Shall I do that, or is it not worth it?