### PR TITLE
Fix syntax error for 0.13.x version of `purs`

### DIFF
--- a/test/Test/Main.js
+++ b/test/Test/Main.js
@@ -6,3 +6,4 @@ exports.thisIsNumber = 12;
 exports.thisIsString = "foobar";
 exports.thisIsArray = ["foo", "bar"];
 exports.thisIsObject = { foo: "bar" };
+exports.thisIsInvalidString = "\\\ffff";

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -23,6 +23,7 @@ foreign import thisIsNumber :: Json
 foreign import thisIsString :: Json
 foreign import thisIsArray :: Json
 foreign import thisIsObject :: Json
+foreign import thisIsInvalidString :: String
 
 isTest :: Effect Unit
 isTest = do
@@ -120,7 +121,7 @@ toTest = do
 
 parserTest :: Effect Unit
 parserTest = do
-  assert ((isLeft (jsonParser "\\\ffff")) <?> "Error in jsonParser")
+  assert ((isLeft (jsonParser thisIsInvalidString)) <?> "Error in jsonParser")
   quickCheck' 10 roundtripTest
   where
   roundtripTest :: Gen Result


### PR DESCRIPTION
## What does this pull request do?

As found in #34, CI is currently broken on 0.13.x of `purs`. This PR offers one way to fix the issue. If we'd prefer not to solve it in this way, feel free to recommend an alternative. More than happy to try something else.

## Where should the reviewer start?

* `\ffff` is now a syntax error in 0.13.x. See [a failing build](https://travis-ci.org/purescript-contrib/purescript-argonaut-core/builds/576467100#L1484-L1494) for what the exact error is.