### PR TITLE
feat: stringifyWithSpace -> add method similar to elm encode

### DIFF
--- a/src/Data/Argonaut/Core.js
+++ b/src/Data/Argonaut/Core.js
@@ -16,6 +16,12 @@ exports.stringify = function (j) {
   return JSON.stringify(j);
 };
 
+exports.stringifyWithIndent = function (i) {
+  return function (j) {
+    return JSON.stringify(j, null, i);
+  };
+};
+
 function isArray(a) {
   return Object.prototype.toString.call(a) === "[object Array]";
 }

--- a/src/Data/Argonaut/Core.purs
+++ b/src/Data/Argonaut/Core.purs
@@ -37,6 +37,7 @@ module Data.Argonaut.Core
   , jsonEmptyObject
   , jsonSingletonObject
   , stringify
+  , stringifyWithIndent
   ) where
 
 import Prelude
@@ -178,13 +179,13 @@ toObject = toJsonType caseJsonObject
 
 -- Encoding
 
--- | Construct `Json` from a `Boolean` value 
+-- | Construct `Json` from a `Boolean` value
 foreign import fromBoolean :: Boolean -> Json
 
--- | Construct `Json` from a `Number` value 
+-- | Construct `Json` from a `Number` value
 foreign import fromNumber :: Number -> Json
 
--- | Construct `Json` from a `String` value. If you would like to parse a string 
+-- | Construct `Json` from a `String` value. If you would like to parse a string
 -- | of JSON into valid `Json`, see `jsonParser`.
 foreign import fromString :: String -> Json
 
@@ -234,6 +235,11 @@ jsonSingletonObject key val = fromObject (Obj.singleton key val)
 -- | Converts a `Json` value to a JSON string. To retrieve a string from a `Json`
 -- | string value, see `fromString`.
 foreign import stringify :: Json -> String
+
+-- | Converts a `Json` value to a JSON string.
+-- | The first `Int` argument specifies the amount of white space characters to use as indentation.
+-- | This number is capped at 10 (if it is greater, the value is just 10). Values less than 1 indicate that no space should be used.
+foreign import stringifyWithIndent :: Int -> Json -> String
 
 foreign import _caseJson
   :: forall z


### PR DESCRIPTION
## What does this pull request do?

it adds function similar to https://package.elm-lang.org/packages/elm/json/latest/Json-Encode#encode

this pr consumes https://github.com/purescript-contrib/purescript-argonaut-core/pull/29 and https://github.com/purescript-contrib/purescript-argonaut-core/pull/23

the difference is:
- from #29 - no `...space` alias, and not `...indent`, but `...indentation`, because I prefer full name
- from #23 - again not `...space`

it adds `stringifyWithIndentation` function