### PR TITLE
Add more details contrasting `fromString` and `jsonParser`

### DIFF
--- a/src/Data/Argonaut/Core.purs
+++ b/src/Data/Argonaut/Core.purs
@@ -185,8 +185,12 @@ foreign import fromBoolean :: Boolean -> Json
 -- | Construct `Json` from a `Number` value
 foreign import fromNumber :: Number -> Json
 
--- | Construct `Json` from a `String` value. If you would like to parse a string
--- | of JSON into valid `Json`, see `jsonParser`.
+-- | Construct `Json` from a `String` value.
+-- | Note that this function only produces a `Json` object containing a single piece of `String`
+-- | data (similar to `fromBoolean`, `fromNumber`, etc.). These "fromX" functions are often
+-- | used to build-up JSON objects manually, as opposed to using `encodeJson`.
+-- | This function does NOT convert the `String` encoding of a JSON object to `Json` - For that
+-- | purpose, you'll need to use `jsonParser`.
 foreign import fromString :: String -> Json
 
 -- | Construct `Json` from an array of `Json` values

--- a/src/Data/Argonaut/Core.purs
+++ b/src/Data/Argonaut/Core.purs
@@ -185,11 +185,10 @@ foreign import fromBoolean :: Boolean -> Json
 -- | Construct `Json` from a `Number` value
 foreign import fromNumber :: Number -> Json
 
--- | Construct `Json` from a `String` value.
--- | Note that this function only produces a `Json` object containing a single piece of `String`
--- | data (similar to `fromBoolean`, `fromNumber`, etc.). These "fromX" functions are often
--- | used to build-up JSON objects manually, as opposed to using `encodeJson`.
--- | This function does NOT convert the `String` encoding of a JSON object to `Json` - For that
+-- | Construct the `Json` representation of a `String` value.
+-- | Note that this function only produces `Json` containing a single piece of `String`
+-- | data (similar to `fromBoolean`, `fromNumber`, etc.).
+-- | This function does NOT convert the `String` encoding of a JSON value to `Json` - For that
 -- | purpose, you'll need to use `jsonParser`.
 foreign import fromString :: String -> Json
 


### PR DESCRIPTION
**Description of the change**

I recently found `fromString` when searching pursuit for `String -> Json`, and misunderstood how it's different from `jsonParser`. I assumed `jsonParser` just frontloads some error-checking that would otherwise be handled by `decodeJson`. This change adds some clarifying details.


**Checklist:**

Is changelog necessary for a documentation edit?
- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username

Not applicaple
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
