### PR TITLE
update spago.dhall and bower.json for added direct dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "purescript-console": "^5.0.0",
     "purescript-effect": "^3.0.0",
-    "purescript-quickcheck": "^7.0.0"
+    "purescript-partial": "^3.0.0",
+    "purescript-quickcheck": "^7.0.0",
+    "purescript-tuples": "^6.0.0"
   }
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -10,11 +10,13 @@
   , "gen"
   , "maybe"
   , "nonempty"
+  , "partial"
   , "prelude"
   , "psci-support"
   , "quickcheck"
   , "strings"
   , "tailrec"
+  , "tuples"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]


### PR DESCRIPTION
**Description of the change**
Fixes the failed CI run by listing additional direct dependencies in spago.dhall and bower.json.  (See [purescript-contrib/governance#43](https://github.com/purescript-contrib/governance/issues/43).

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
