### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 !.eslintrc.json
 
 output

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#53 by @thomashoneyman)
 * Fixed readme bug where `jsonParser` was imported from `Data.Argonaut.Core` instead of `Data.Argonaut.Parser` (#50 by @flip111)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-argonaut-core/releases/tag/v6.0.0) - 2021-02-26

--- a/src/Data/Argonaut/Core.purs
+++ b/src/Data/Argonaut/Core.purs
@@ -78,7 +78,8 @@ caseJson
   -> (String -> a)
   -> (Array Json -> a)
   -> (Object Json -> a)
-  -> Json -> a
+  -> Json
+  -> a
 caseJson a b c d e f json = runFn7 _caseJson a b c d e f json
 
 -- | A simpler version of `caseJson` which accepts a callback for when the
@@ -229,7 +230,7 @@ jsonEmptyObject = fromObject Obj.empty
 
 -- | Constructs a `Json` array value containing only the provided value
 jsonSingletonArray :: Json -> Json
-jsonSingletonArray j = fromArray [j]
+jsonSingletonArray j = fromArray [ j ]
 
 -- | Constructs a `Json` object value containing only the provided key and value
 jsonSingletonObject :: String -> Json -> Json
@@ -247,13 +248,13 @@ foreign import stringifyWithIndent :: Int -> Json -> String
 foreign import _caseJson
   :: forall z
    . Fn7
-      (Unit -> z)
-      (Boolean -> z)
-      (Number -> z)
-      (String -> z)
-      (Array Json -> z)
-      (Object Json -> z)
-      Json
-      z
+       (Unit -> z)
+       (Boolean -> z)
+       (Number -> z)
+       (String -> z)
+       (Array Json -> z)
+       (Object Json -> z)
+       Json
+       z
 
 foreign import _compare :: Fn5 Ordering Ordering Ordering Json Json Ordering

--- a/src/Data/Argonaut/Gen.purs
+++ b/src/Data/Argonaut/Gen.purs
@@ -23,7 +23,7 @@ genJson = Gen.resize (min 5) $ Gen.sized genJson'
     | otherwise = genLeaf
 
   genLeaf :: m J.Json
-  genLeaf = Gen.oneOf $ pure J.jsonNull :| [genJBoolean, genJNumber, genJString]
+  genLeaf = Gen.oneOf $ pure J.jsonNull :| [ genJBoolean, genJNumber, genJString ]
 
   genJArray :: m J.Json
   genJArray = J.fromArray <$> Gen.unfoldable (defer \_ -> genJson)

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -45,12 +45,12 @@ foldTest = do
 
 foldFn :: Json -> String
 foldFn = caseJson
-         (const "null")
-         (const "boolean")
-         (const "number")
-         (const "string")
-         (const "array")
-         (const "object")
+  (const "null")
+  (const "boolean")
+  (const "number")
+  (const "string")
+  (const "array")
+  (const "object")
 
 cases :: Array Json
 cases =
@@ -64,27 +64,38 @@ cases =
 
 foldXXX :: Effect Unit
 foldXXX = do
-  assert ((caseJsonNull "not null" (const "null") <$> cases) ==
-          ["null", "not null", "not null", "not null", "not null", "not null"] <?>
-          "Error in caseJsonNull")
-  assert ((caseJsonBoolean "not boolean" (const "boolean") <$> cases) ==
-          ["not boolean", "boolean", "not boolean", "not boolean", "not boolean", "not boolean"] <?>
-          "Error in caseJsonBoolean")
-  assert ((caseJsonNumber "not number" (const "number") <$> cases) ==
-          ["not number", "not number", "number", "not number", "not number", "not number"] <?>
-          "Error in caseJsonNumber")
+  assert
+    ( (caseJsonNull "not null" (const "null") <$> cases) ==
+        [ "null", "not null", "not null", "not null", "not null", "not null" ] <?>
+        "Error in caseJsonNull"
+    )
+  assert
+    ( (caseJsonBoolean "not boolean" (const "boolean") <$> cases) ==
+        [ "not boolean", "boolean", "not boolean", "not boolean", "not boolean", "not boolean" ] <?>
+        "Error in caseJsonBoolean"
+    )
+  assert
+    ( (caseJsonNumber "not number" (const "number") <$> cases) ==
+        [ "not number", "not number", "number", "not number", "not number", "not number" ] <?>
+        "Error in caseJsonNumber"
+    )
 
-  assert ((caseJsonString "not string" (const "string") <$> cases) ==
-          ["not string", "not string", "not string", "string", "not string", "not string"] <?>
-          "Error in caseJsonString")
+  assert
+    ( (caseJsonString "not string" (const "string") <$> cases) ==
+        [ "not string", "not string", "not string", "string", "not string", "not string" ] <?>
+        "Error in caseJsonString"
+    )
 
-  assert ((caseJsonArray "not array" (const "array") <$> cases) ==
-          ["not array", "not array", "not array", "not array", "array", "not array"] <?>
-          "Error in caseJsonArray")
-  assert ((caseJsonObject "not object" (const "object") <$> cases) ==
-          ["not object", "not object", "not object", "not object", "not object", "object"] <?>
-          "Error in caseJsonObject")
-
+  assert
+    ( (caseJsonArray "not array" (const "array") <$> cases) ==
+        [ "not array", "not array", "not array", "not array", "array", "not array" ] <?>
+        "Error in caseJsonArray"
+    )
+  assert
+    ( (caseJsonObject "not object" (const "object") <$> cases) ==
+        [ "not object", "not object", "not object", "not object", "not object", "object" ] <?>
+        "Error in caseJsonObject"
+    )
 
 fromTest :: Effect Unit
 fromTest = do
@@ -92,16 +103,24 @@ fromTest = do
   quickCheck (\bool -> caseJsonBoolean Nothing Just (fromBoolean bool) == Just bool <?> "Error in fromBoolean")
   quickCheck (\num -> caseJsonNumber Nothing Just (fromNumber num) == Just num <?> "Error in fromNumber")
   quickCheck (\str -> caseJsonString Nothing Just (fromString str) == Just str <?> "Error in fromString")
-  quickCheck (\num ->
-               let arr :: Array Json
-                   arr = A.singleton (fromNumber num)
-               in (caseJsonArray Nothing  Just (fromArray arr) == Just arr)
-                  <?> "Error in fromArray")
-  quickCheck (\(Tuple str num) ->
-               let sm :: Obj.Object Json
-                   sm = Obj.singleton str (fromNumber num)
-               in (caseJsonObject Nothing Just (fromObject sm) == Just sm)
-                  <?> "Error in fromObject")
+  quickCheck
+    ( \num ->
+        let
+          arr :: Array Json
+          arr = A.singleton (fromNumber num)
+        in
+          (caseJsonArray Nothing Just (fromArray arr) == Just arr)
+            <?> "Error in fromArray"
+    )
+  quickCheck
+    ( \(Tuple str num) ->
+        let
+          sm :: Obj.Object Json
+          sm = Obj.singleton str (fromNumber num)
+        in
+          (caseJsonObject Nothing Just (fromObject sm) == Just sm)
+            <?> "Error in fromObject"
+    )
 
 toTest :: Effect Unit
 toTest = do
@@ -114,10 +133,11 @@ toTest = do
   where
   assertion :: forall a. (Eq a) => (Json -> Maybe a) -> Json -> String -> Result
   assertion fn j msg =
-    let forCases = A.catMaybes (fn <$> cases)
-        exact = A.singleton $ unsafePartial fromJust $ fn j
-    in forCases == exact <?> msg
-
+    let
+      forCases = A.catMaybes (fn <$> cases)
+      exact = A.singleton $ unsafePartial fromJust $ fn j
+    in
+      forCases == exact <?> msg
 
 parserTest :: Effect Unit
 parserTest = do
@@ -128,7 +148,7 @@ parserTest = do
   roundtripTest = do
     json <- Gen.resize (const 5) genJson
     let parsed = jsonParser (stringify json)
-    pure $ parsed == Right json <?> show (stringify <$> parsed) <> " /= " <> stringify json 
+    pure $ parsed == Right json <?> show (stringify <$> parsed) <> " /= " <> stringify json
 
 assert :: forall prop. Testable prop => prop -> Effect Unit
 assert = quickCheck' 1


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
