### PR TITLE
Add fromInt function

### DIFF
--- a/src/Data/Argonaut/Core.purs
+++ b/src/Data/Argonaut/Core.purs
@@ -18,6 +18,7 @@ module Data.Argonaut.Core
   , isObject
   , fromBoolean
   , fromNumber
+  , fromInt
   , fromString
   , fromArray
   , fromObject
@@ -44,6 +45,7 @@ import Prelude
 
 import Data.Function.Uncurried (Fn5, runFn5, Fn7, runFn7)
 import Data.Maybe (Maybe(..))
+import Data.Int (toNumber)
 import Foreign.Object (Object)
 import Foreign.Object as Obj
 
@@ -185,6 +187,9 @@ foreign import fromBoolean :: Boolean -> Json
 
 -- | Construct `Json` from a `Number` value
 foreign import fromNumber :: Number -> Json
+
+fromInt :: Int -> Json
+fromInt int = fromNumber $ toNumber int
 
 -- | Construct the `Json` representation of a `String` value.
 -- | Note that this function only produces `Json` containing a single piece of `String`


### PR DESCRIPTION
Allows conversion from purescript primitive type `Int` to `Json`

Checklist below i can do after first review

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
